### PR TITLE
Add slash and question mark to lower layer

### DIFF
--- a/keyboards/stenokeyboards/polyglot/keymaps/everything_qwerty/keymap.c
+++ b/keyboards/stenokeyboards/polyglot/keymaps/everything_qwerty/keymap.c
@@ -79,9 +79,9 @@ const uint16_t PROGMEM keymaps[][MATRIX_ROWS][MATRIX_COLS] = {
   //,-----------------------------------------------------.                    ,-----------------------------------------------------.
        PLOVER, KC_EXLM,   KC_AT, KC_HASH,  KC_DLR, KC_PERC,                      KC_CIRC, KC_AMPR, KC_ASTR, KC_LPRN, KC_RPRN, KC_BSPC,
   //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
-       _______, _______, KC_MUTE, KC_VOLD, KC_VOLU, _______,               KC_MINS,  KC_EQL, KC_LBRC, KC_RBRC, KC_BSLS,  KC_GRV,
+       _______, _______, KC_MUTE, KC_VOLD, KC_VOLU, _______,               KC_SLSH,  KC_EQL, KC_LBRC, KC_RBRC, KC_BSLS,  KC_GRV,
   //|--------+--------+--------+--------+--------+--------|                    |--------+--------+--------+--------+--------+--------|
-      GEMINI, RGB_VAD, RGB_VAI, RGB_HUD, RGB_HUI, RGB_MODE_FORWARD,                      KC_UNDS, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE, KC_TILD,
+      GEMINI, RGB_VAD, RGB_VAI, RGB_HUD, RGB_HUI, RGB_MODE_FORWARD,                      KC_QUES, KC_PLUS, KC_LCBR, KC_RCBR, KC_PIPE, KC_TILD,
   //|--------+--------+--------+--------+--------+--------+--------|  |--------+--------+--------+--------+--------+--------+--------|
                                           _______,XXXXXXX, _______,    _______, _______, _______
                                       //`--------------------------'  `--------------------------'


### PR DESCRIPTION
The Polyglot `everything` firmware includes a Dvorak layer. This layer is missing the quotation mark and forward slash characters. These characters are not available on any other layer provided. This change updates the lower layer to include these characters instead of dash and underscore.

Unfortunately the dash and underscore characters are not available on the Qwerty layer, so this change introduces an issue for Qwerty users.

## Description

<!--- Describe your changes in detail here. -->

## Types of Changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->
- [ ] Core
- [ ] Bugfix
- [ ] New feature
- [ ] Enhancement/optimization
- [ ] Keyboard (addition or update)
- [ ] Keymap/layout/userspace (addition or update)
- [ ] Documentation
- [x] Quirky change that only Dvorak users would want. Introduces issues for Qwerty users.

## Issues Fixed or Closed by This PR

* 

## Checklist

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the [**CONTRIBUTING** document](https://docs.qmk.fm/#/contributing).
- [ ] I have added tests to cover my changes.
- [ ] I have tested the changes and verified that they work and don't break anything (as well as I can manage).
